### PR TITLE
fix: broken code of conduct link in FAQ page

### DIFF
--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -35,7 +35,7 @@ export default () => {
         <Styled.h3>Is there a Code of Conduct (CoC)?</Styled.h3>
         <Styled.p>
           Yes, by attending you are agreeing to the CoC. Details on the CoC can
-          be found <Styled.a href="/coc">here</Styled.a>.
+          be found <Styled.a href="/code-of-conduct">here</Styled.a>.
         </Styled.p>
         <Styled.h3>Who do I contact for CoC violations?</Styled.h3>
         <Styled.p>


### PR DESCRIPTION
The CoC link in the banner was fixed in 15643736d0ff81e35b29705a65c24aef9c52a3d5, and it looks like this CoC link also needed to be updated. Clicking on the "code of conduct" link mentioned in the FAQ navigates the user to a 404 page.