### PR TITLE
Remove 2020 info from site

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,44 +32,6 @@ export default (props) => {
           >
             JavaScript conference hosted in Nashville.
           </Styled.h1>
-          <Styled.h3
-            css={css({
-              textAlign: 'center',
-              color: 'background',
-              textShadow: '0px 0px 5px black',
-            })}
-          >
-            2020 details coming soon!
-          </Styled.h3>
-        </Container>
-      </Box>
-      <Box>
-        <Container>
-          <Styled.h3
-            css={css({
-              textAlign: 'center',
-            })}
-          >
-            <Styled.a
-              title="Call for Speakers"
-              href="https://sessionize.com/ugjs-2020"
-            >
-              CFP Now Open
-            </Styled.a>
-          </Styled.h3>
-
-          <Styled.h3
-            css={css({
-              textAlign: 'center',
-            })}
-          >
-            <Styled.a
-              title="Tickets"
-              href="https://www.eventbrite.com/e/undergroundjs-2020-tickets-93439517111?aff=website"
-            >
-              Buy Tickets
-            </Styled.a>
-          </Styled.h3>
         </Container>
       </Box>
     </Layout>


### PR DESCRIPTION
Realized that the CFP and ticket links were still up. Removing those in case anyone stumbles upon the site.